### PR TITLE
Include a build number in the version.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.12.2
 forge_version=14.23.4.2705
-mod_version=3.0.0
+mod_version=3.0.0-1
 patchouli_version=1.0-11.60
 
 # Set this to true to enable dependencies


### PR DESCRIPTION
That way when you release a new change people can say "I'm using build -X" instead of "I'm also on 3.0.0 with no change".