### PR TITLE
Move the final references to runic shears to advancement-locked pages.

### DIFF
--- a/src/main/resources/assets/roots/patchouli_books/roots_guide/en_us/entries/herbs/baffle_cap.json
+++ b/src/main/resources/assets/roots/patchouli_books/roots_guide/en_us/entries/herbs/baffle_cap.json
@@ -7,11 +7,16 @@
   "pages": [
     {
       "type": "text",
-      "text": "Baffle Caps are a bizarre variety of fungus, the spores of which seem to confound those who mishandle it.$(br2)Baffle Caps can be obtained by using Runic Shears on ordinary mushrooms."
+      "text": "Baffle Caps are a bizarre variety of fungus, the spores of which seem to confound those who mishandle it."
     },
     {
       "type": "ritual_crafting_template",
       "recipe": "baffle_cap"
+    },
+    {
+      "advancement": "roots:runic_shears",
+      "type": "text",
+      "text": "Baffle Caps can also be obtained by using Runic Shears on ordinary mushrooms."
     }
   ]
 }

--- a/src/main/resources/assets/roots/patchouli_books/roots_guide/en_us/entries/herbs/pereskia.json
+++ b/src/main/resources/assets/roots/patchouli_books/roots_guide/en_us/entries/herbs/pereskia.json
@@ -10,12 +10,13 @@
       "text": "A vibrant plant full of magical energy. Both the bulbs and the flowers that grow from them have different magical applications, which has earned this plant the nickname 'Feyblossom' among some circles - in reference to legends which state the flower was originally cultivated in the gardens of fairies."
     },
     {
-      "type": "text",
-      "text": "Pereskia flowers can be obtained by using Runic Shears on dandelions or poppies, and then crafted into bulbs to propogate them further."
-    },
-    {
       "type": "ritual_crafting_template",
       "recipe": "pereskia"
+    },
+    {
+      "advancement": "roots:runic_shears",
+      "type": "text",
+      "text": "Pereskia flowers can also be obtained by using Runic Shears on dandelions or poppies. These can then be crafted into bulbs in order to propagate them further."
     }
   ]
 }


### PR DESCRIPTION
Still requires an actual visual on runic shears + herb = blah, but I'm
not sure what the templates for that are.